### PR TITLE
deleted ports on keycloak frontend redirectUrls

### DIFF
--- a/config/klockan-realm.json
+++ b/config/klockan-realm.json
@@ -718,7 +718,7 @@
       "name": "",
       "description": "",
       "rootUrl": "",
-      "adminUrl": "https://localhost:4200/",
+      "adminUrl": "https://localhost/",
       "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
@@ -726,10 +726,10 @@
       "clientAuthenticatorType": "client-jwt",
       "secret": "**********",
       "redirectUris": [
-        "https://localhost:4200/*"
+        "https://localhost/*"
       ],
       "webOrigins": [
-        "https://localhost:4200/*"
+        "https://localhost/*"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
# Summary

_Changed frontend references to fit nginx https handling for frontend_

# Details

_Add more context to describe the changes..._

* Modified config/klockan-realm.json frontend references

# Evidence

![image](https://github.com/JU-DEV-LatamBootcamp/Klockan-Backend/assets/151551082/de772c98-5c4f-4051-aacc-931f7e63287d)

# References
- Issue: [#127 [Bugfix] Fix all frontend endpoint references across project](https://tree.taiga.io/project/marcel-morales-klockan/issue/127)
- Backend: https://github.com/JU-DEV-LatamBootcamp/Klockan-Backend/pull/31
- Frontend https://github.com/JU-DEV-LatamBootcamp/Klockan-Frontend/pull/34